### PR TITLE
Move DSToken creation out of constructor

### DIFF
--- a/src/tub.sol
+++ b/src/tub.sol
@@ -59,12 +59,11 @@ contract Tub is DSAuth, DSNote, DSMath {
         uint128  ink;      // Locked collateral (in skr)
     }
 
-    function Tub(ERC20 gem_) {
+    function Tub(ERC20 gem_, DSToken sai_, DSToken sin_, DSToken skr_) {
         gem = gem_;
-
-        sai = new DSToken("SAI", "SAI", 18);
-        sin = new DSToken("SIN", "SIN", 18);
-        skr = new DSToken("SKR", "SKR", 18);
+        sai = sai_;
+        sin = sin_;
+        skr = skr_;
 
         axe = RAY;
         mat = RAY;

--- a/src/tub.t.sol
+++ b/src/tub.t.sol
@@ -8,10 +8,23 @@ import './tub.sol';
 contract Test is DSTest {
     Tub tub;
     DSToken _gem;
+    DSToken _sai;
+    DSToken _sin;
+    DSToken _skr;
     function setUp() {
         _gem = new DSToken("collateral", "COL", 18);
         _gem.mint(100 ether);
-        tub = new Tub(_gem);
+
+        _sai = new DSToken("SAI", "SAI", 18);
+        _sin = new DSToken("SIN", "SIN", 18);
+        _skr = new DSToken("SKR", "SKR", 18);
+        
+        tub = new Tub(_gem, _sai, _sin, _skr);
+
+        _sai.setOwner(tub);
+        _sin.setOwner(tub);
+        _skr.setOwner(tub);
+
         _gem.approve(tub, 100000 ether);
         tub.skr().approve(tub, 100000 ether);
         tub.sai().approve(tub, 100000 ether);


### PR DESCRIPTION
Constructor accepts 4 tokens:

`function Tub(ERC20 gem_, DSToken sai_, DSToken sin_, DSToken skr_)`

Reduced gas cost substantially for contract creation (from `5.3 M` to `2.6 M`) in case we want to upload to Kovan.

In `tub.t.sol`, Test creates `sai`, `sin` and `skr` and gives ownership to `tub`.