### PR TITLE
Adding LogNewCup event

### DIFF
--- a/src/tub.sol
+++ b/src/tub.sol
@@ -164,6 +164,7 @@ contract Tub is DSThing, TubEvents {
         aver(!off);
         cup = bytes32(++cupi);
         cups[cup].lad = msg.sender;
+        // TODO replace this event with another solution
         LogNewCup(msg.sender, cup);
     }
     function shut(bytes32 cup) note {


### PR DESCRIPTION
This event is necessary for building the list of cups of each user.
`LogNote` should be enough for tracking the rest of actions.