### PR TITLE
22 bust boom params

### DIFF
--- a/src/tub.sol
+++ b/src/tub.sol
@@ -259,20 +259,20 @@ contract Tub is DSThing, TubEvents {
     function boom(uint128 wad) auth note {
         assert(reg == Stage.Usual);
         mend();
+        assert(wad <= joy());
 
-        // price of wad in sai
-        var ret = rmul(wmul(wad, tag()), per());
-        assert(ret <= joy());
+        // price of wad in skr after burning `jam` `skr`
+        var jam = wdiv(uint128(skr.totalSupply()), hadd(wdiv(wmul(tag(), pie()), wad), 1 ether));
 
-        skr.pull(msg.sender, wad);
-        skr.burn(wad);
+        skr.pull(msg.sender, jam);
+        skr.burn(jam);
 
-        sai.push(msg.sender, ret);
+        sai.push(msg.sender, wad);
     }
     function bust(uint128 wad) auth note {
         assert(reg == Stage.Usual);
-        assert(wad <= woe());
         mend();
+        assert(wad <= woe());
 
         var jam = rdiv(wdiv(wad, tag()), per()); // Calculates 'jam' using actual 'per' (assuming there is not need to 'mint' 'skr')
         if (jam > fog()) {

--- a/src/tub.t.sol
+++ b/src/tub.t.sol
@@ -783,6 +783,33 @@ contract TubTest is DSTest, DSMath {
         assertEq(skr.totalSupply(), skrEquivalentAfterMint);
     }
 
+    function testBoom() {
+        tub.cork(100 ether);
+        tub.cuff(ray(wdiv(3 ether, 2 ether)));  // 150% liq limit
+        mark(2 ether);
+
+        tub.join(10 ether);
+        var cup = tub.open();
+        tub.lock(cup, 10 ether);
+
+        mark(3 ether);
+        tub.draw(cup, 16 ether);
+
+        assertEq(sai.balanceOf(this), 16 ether);
+        sai.transfer(tub, 16 ether); // Temporary workaround to be able to call boom without fees implementation
+        assertEq(sai.balanceOf(this), 0);
+
+        assertEqWad(tub.joy(), 16 ether);
+
+        tub.join(10 ether);
+        tub.boom(16 ether);
+
+        assertEqWad(tub.joy(), 0 ether);
+        assertEq(sai.balanceOf(this), 16 ether);
+
+        assertEqWad(uint128(skr.balanceOf(this)), hsub(10 ether, rdiv(wdiv(16 ether, tub.tag()), tub.per())));
+    }
+
     function testCascade() {
         // demonstrate liquidation cascade
         tub.cork(1000 ether);


### PR DESCRIPTION
Changing `bust` and `boom` parameters to receive `sai` amounts instead of `skr`.