### PR TITLE
way: holder 'fee'

### DIFF
--- a/src/tub.t.sol
+++ b/src/tub.t.sol
@@ -1182,3 +1182,114 @@ contract TaxTest is TubTestBase {
         // distributed if system in surplus
     }
 }
+
+contract WayTest is TubTestBase {
+    function waySetup() returns (bytes32 cup) {
+        mark(10 ether);
+        gem.mint(1000 ether);
+
+        tub.cork(1000 ether);
+
+        cup = tub.open();
+        tub.join(100 ether);
+        tub.lock(cup, 100 ether);
+        tub.draw(cup, 100 ether);
+    }
+    // what does way actually do?
+    // it changes the value of sai relative to ref
+    // way > 1 -> par increasing, more ref per sai
+    // way < 1 -> par decreasing, less ref per sai
+
+    // this changes the safety level of cups,
+    // affecting `draw`, `wipe`, `free` and `bite`
+
+    // if way < 1, par is decreasing and the con (in ref)
+    // of a cup is decreasing, so cup holders need
+    // less ref to wipe (but the same sai)
+    // This makes cups *more* collateralised with time.
+    function testTau() {
+        assertEq(uint(tub.era()), now);
+        assertEq(uint(tub.tau()), now);
+    }
+    function testWayPar() {
+        tub.coax(ray(0.95 ether));
+
+        assertEqWad(tub.par(), 1.00 ether);
+        tub.warp(1);
+        assertEqWad(tub.par(), 0.95 ether);
+
+        tub.coax(ray(2 ether));
+        tub.warp(1);
+        assertEqWad(tub.par(), 1.90 ether);
+    }
+    function testWayDecreasingPrincipal() {
+        var cup = waySetup();
+        mark(0.98 ether);
+        assert(!tub.safe(cup));
+
+        tub.coax(ray(0.95 ether));
+        tub.warp(1);
+        assert(tub.safe(cup));
+    }
+    // `cage` is slightly affected: the cage price is
+    // now in *sai per gem*, where before ref per gem
+    // was equivalent.
+    // `bail` is unaffected, as all values are in sai.
+
+    // `boom` and `bust` as par is now needed to determine
+    // the skr / sai price.
+    function testWayBust() {
+        var cup = waySetup();
+        mark(0.5 ether);
+        tub.bite(cup);
+
+        assertEqWad(tub.joy(),   0 ether);
+        assertEqWad(tub.woe(), 100 ether);
+        assertEqWad(tub.fog(), 100 ether);
+        assertEq(sai.balanceOf(this), 100 ether);
+
+        tub.bust(50 ether);
+
+        assertEqWad(tub.fog(),  50 ether);
+        assertEqWad(tub.woe(),  75 ether);
+        assertEq(sai.balanceOf(this), 75 ether);
+
+        tub.coax(ray(0.5 ether));
+        tub.warp(1);
+        assertEqWad(tub.par(), 0.5 ether);
+        // sai now worth half as much, so we cover twice as much debt
+        // for the same skr
+        tub.bust(50 ether);
+
+        assertEqWad(tub.fog(),   0 ether);
+        assertEqWad(tub.woe(),  25 ether);
+        assertEq(sai.balanceOf(this), 25 ether);
+    }
+    function testWayBoom() {
+        var cup = waySetup();
+        tub.join(100 ether);       // give us some spare skr
+        sai.push(tub, 100 ether);  // force some joy into the tub
+
+        assertEqWad(tub.joy(), 100 ether);
+        mark(2 ether);
+        tub.coax(ray(2 ether));
+        tub.warp(1);
+        assertEqWad(tub.par(), 2 ether);
+        tub.boom(100 ether);
+        assertEqWad(tub.joy(),   0 ether);
+        assertEqWad(tub.per(), ray(2 ether));
+
+        tub.join(100 ether);
+        tub.draw(cup, 100 ether);
+        sai.push(tub, 100 ether);  // force some joy into the tub
+
+        // n.b. per is now 2
+        assertEqWad(tub.joy(), 100 ether);
+        mark(2 ether);
+        tub.coax(ray(0.5 ether));
+        tub.warp(2);
+        assertEqWad(tub.par(), 0.5 ether);
+        tub.boom(12.5 ether);
+        assertEqWad(tub.joy(),   0 ether);
+    }
+}


### PR DESCRIPTION
1) `par` is renamed to `fit` (gem per skr on `cage`)
2) `par` is reintroduced as the price of sai (ref per sai)
3) `way` is introduced as the rate of change of `par`
4) `coax` is used to adjust `way`

What does `way` actually do? It changes the value of sai in terms of ref: 

- `way > 1` gives `par` increasing over time, giving more ref per sai
- `way < 1` gives `par` decreasing over time, giving less ref per sai

This affects the safety margin of cups, as this is calculated in terms of ref. This affects `draw`, `wipe`, `free` and `bite`.

`cage` is slightly affected. The argument to `cage` is the cage price, which is now explicitly in terms of *sai per gem*. `bail` and `cash` are unaffected.

`boom` and `bust` need to know the skr / sai price, so need to read `par`.
