### PR TITLE
fee: continuous CDP holder fees, payable on wipe

### DIFF
--- a/src/mom.sol
+++ b/src/mom.sol
@@ -42,6 +42,13 @@ contract SaiMom is DSThing {
         require(RAY <= tax);
         require(tax < 10002 * 10 ** 23);  // ~200% per hour
     }
+    // Governance fee
+    function setFee(uint ray) public note auth {
+        tub.mold("fee", ray);
+        var fee = tub.fee();
+        require(RAY <= fee);
+        require(fee < 10002 * 10 ** 23);  // ~200% per hour
+    }
     // Liquidation fee
     function setAxe(uint ray) public note auth {
         tub.mold("axe", ray);

--- a/src/sai.t.sol
+++ b/src/sai.t.sol
@@ -33,10 +33,12 @@ contract DevTub is SaiTub, TestWarp {
         DSToken  sin_,
         DSToken  skr_,
         ERC20    gem_,
+        DSToken  gov_,
         DSValue  pip_,
+        DSValue  pep_,
         SaiVox   vox_,
         address  tap_
-    ) public SaiTub(sai_, sin_, skr_, gem_, pip_, vox_, tap_) {}
+    ) public SaiTub(sai_, sin_, skr_, gem_, gov_, pip_, pep_, vox_, tap_) {}
 }
 
 contract DevTop is SaiTop, TestWarp {
@@ -71,8 +73,10 @@ contract SaiTestBase is DSTest, DSMath {
     DSToken  sai;
     DSToken  sin;
     DSToken  skr;
+    DSToken  gov;
 
     DSValue  tag;
+    DSValue  pep;
     DSGuard  dad;
 
     function ray(uint256 wad) internal pure returns (uint256) {
@@ -82,8 +86,12 @@ contract SaiTestBase is DSTest, DSMath {
         return wdiv(ray_, RAY);
     }
 
-    function mark(uint256 price) internal {
+    function mark(uint price) internal {
         tag.poke(bytes32(price));
+    }
+    function mark(DSToken tkn, uint price) internal {
+        if (tkn == gov) pep.poke(bytes32(price));
+        else if (tkn == gem) mark(price);
     }
     function warp(uint256 age) internal {
         vox.warp(age);
@@ -153,6 +161,11 @@ contract SaiTestBase is DSTest, DSMath {
         dad.permit(this, skr, bytes4(keccak256('mint(address,uint256)')));
         dad.permit(this, skr, bytes4(keccak256('burn(address,uint256)')));
 
+        // gov would actually have its owner / authority outside the
+        // system. Set to `dad` for convenience.
+        gov.setAuthority(dad);
+        dad.permit(tub, gov, bytes4(keccak256('burn(address,uint256)')));
+
         dad.setOwner(0);
     }
 
@@ -165,11 +178,14 @@ contract SaiTestBase is DSTest, DSMath {
 
         skr = new DSToken("SKR");
 
+        gov = new DSToken("GOV");
+
         tag = new DSValue();
+        pep = new DSValue();
         vox = new DevVox();
 
         tap = new SaiTap();
-        tub = new DevTub(sai, sin, skr, gem, tag, vox, tap);
+        tub = new DevTub(sai, sin, skr, gem, gov, tag, pep, vox, tap);
         top = new DevTop(tub, tap);
         tap.turn(tub);
 
@@ -182,11 +198,13 @@ contract SaiTestBase is DSTest, DSMath {
         sai.trust(tub, true);
         skr.trust(tub, true);
         gem.trust(tub, true);
+        gov.trust(tub, true);
 
         sai.trust(tap, true);
         skr.trust(tap, true);
 
-        tag.poke(bytes32(1 ether));
+        mark(1 ether);
+        mark(gov, 1 ether);
 
         mom.setHat(20 ether);
     }
@@ -353,9 +371,15 @@ contract SaiTubTest is SaiTestBase {
         mark(1 ether / 2);       // 125% collateralisation
         assertTrue(!tub.safe(cup));
 
-        assertEq(tap.fog(), uint(0));
+        assertEq(tub.ice(),    4 ether);
+        assertEq(tub.tab(cup), 4 ether);
+        assertEq(tap.fog(),    0 ether);
+        assertEq(tap.woe(),    0 ether);
         tub.bite(cup);
-        assertEq(tap.fog(), uint(8 ether));
+        assertEq(tub.ice(),    0 ether);
+        assertEq(tub.tab(cup), 0 ether);
+        assertEq(tap.fog(),    8 ether);
+        assertEq(tap.woe(),    4 ether);
 
         // cdp should now be safe with 0 sai debt and 2 skr remaining
         var skr_before = skr.balanceOf(this);
@@ -2066,5 +2090,187 @@ contract GasTest is SaiTestBase {
     function testGasDrip1d() public {
         warp(1 days);
         doDrip();
+    }
+}
+
+contract FeeTest is SaiTestBase {
+    function feeSetup() public returns (bytes32 cup) {
+        mark(10 ether);
+        mark(gov, 1 ether / 2);
+        gem.mint(1000 ether);
+        gov.mint(100 ether);
+
+        mom.setHat(1000 ether);
+        mom.setFee(1000000564701133626865910626);  // 5% / day
+
+        // warp(1 days);  // make chi,rhi != 1
+
+        cup = tub.open();
+        tub.join(100 ether);
+        tub.lock(cup, 100 ether);
+        tub.draw(cup, 100 ether);
+    }
+    function testFeeSet() public {
+        assertEq(tub.fee(), ray(1 ether));
+        mom.setFee(ray(1.000000001 ether));
+        assertEq(tub.fee(), ray(1.000000001 ether));
+    }
+    function testFeeSetup() public {
+        feeSetup();
+        assertEq(tub.chi(), ray(1 ether));
+        assertEq(tub.rhi(), ray(1 ether));
+    }
+    function testFeeDrip() public {
+        feeSetup();
+        warp(1 days);
+        assertEq(tub.chi(), ray(1.00 ether));
+        assertEq(tub.rhi() / 10 ** 9, 1.05 ether);
+    }
+    // Unpaid fees accumulate as sin
+    function testFeeIce() public {
+        var cup = feeSetup();
+        assertEq(tub.ice(),    100 ether);
+        assertEq(tub.tab(cup), 100 ether);
+        warp(1 days);
+        assertEq(tub.tab(cup), 105 ether);
+        assertEq(tub.ice(),    105 ether);
+    }
+    function testFeeDraw() public {
+        var cup = feeSetup();
+        warp(1 days);
+        assertEq(tub.tab(cup), 105 ether);
+        tub.draw(cup, 100 ether);
+        assertEq(tub.tab(cup), 205 ether);
+        warp(1 days);
+        assertEq(tub.tab(cup), 215.25 ether);
+    }
+    function testFeeWipe() public {
+        var cup = feeSetup();
+        warp(1 days);
+        assertEq(tub.tab(cup), 105 ether);
+        tub.wipe(cup, 50 ether);
+        assertEq(tub.tab(cup), 55 ether);
+        warp(1 days);
+        assertEq(tub.tab(cup), 57.75 ether);
+    }
+    function testFeeCalcFromRap() public {
+        var cup = feeSetup();
+
+        assertEq(tub.tab(cup), tub.rap(cup));
+        warp(1 days);
+        assertEq(tub.rap(cup), 100 ether);
+        assertEq(tub.tab(cup), 105 ether);
+    }
+    function testFeeWipePays() public {
+        var cup = feeSetup();
+        warp(1 days);
+
+        assertEq(tub.tab(cup), 105 ether);
+        assertEq(gov.balanceOf(this), 100 ether);
+        tub.wipe(cup, 52.5 ether);
+        assertEq(tub.tab(cup), 52.5 ether);
+        assertEq(gov.balanceOf(this), 95 ether);
+    }
+    function testFeeWipeBurns() public {
+        var cup = feeSetup();
+        warp(1 days);
+
+        assertEq(gov.totalSupply(), 100 ether);
+        tub.wipe(cup, 52.5 ether);
+        assertEq(gov.totalSupply(), 95 ether);
+    }
+    function testFeeWipeAll() public {
+        var cup = feeSetup();
+        warp(1 days);
+
+        var wad = tub.tab(cup);
+        assertEq(wad, 105 ether);
+        var owe = sub(wad, rmul(wad, rdiv(tub.rap(cup), tub.tab(cup))));
+        assertEq(owe, 5 ether);
+
+        var ( , , art, irk) = tub.cups(cup);
+        assertEq(art, 100 ether);
+        assertEq(irk, 100 ether);
+        assertEq(rdiv(sub(wad, owe), tub.chi()), art);
+        assertEq(rdiv(wad, tub.rhi()), irk);
+
+        assertEq(tub.tab(cup), 105 ether);
+        assertEq(gov.balanceOf(this), 100 ether);
+        tub.wipe(cup, 105 ether);
+        assertEq(tub.tab(cup), 0 ether);
+        assertEq(gov.balanceOf(this), 90 ether);
+    }
+}
+
+contract FeeTaxTest is SaiTestBase {
+    function feeSetup() public returns (bytes32 cup) {
+        mark(10 ether);
+        mark(gov, 1 ether / 2);
+        gem.mint(1000 ether);
+        gov.mint(100 ether);
+
+        mom.setHat(1000 ether);
+        mom.setFee(1000000564701133626865910626);  // 5% / day
+        mom.setTax(1000000564701133626865910626);  // 5% / day
+
+        // warp(1 days);  // make chi,rhi != 1
+
+        cup = tub.open();
+        tub.join(100 ether);
+        tub.lock(cup, 100 ether);
+        tub.draw(cup, 100 ether);
+    }
+    function testFeeTaxDrip() public {
+        feeSetup();
+        warp(1 days);
+        assertEq(tub.chi() / 10 ** 9, 1.0500 ether);
+        assertEq(tub.rhi() / 10 ** 9, 1.1025 ether);
+    }
+    // Unpaid fees accumulate as sin
+    function testFeeTaxIce() public {
+        var cup = feeSetup();
+        assertEq(tub.ice(),    100 ether);
+        assertEq(tub.tab(cup), 100 ether);
+        warp(1 days);
+        assertEq(tub.tab(cup), 110.25 ether);
+        assertEq(tub.ice(),    110.25 ether);
+    }
+    function testFeeTaxDraw() public {
+        var cup = feeSetup();
+        warp(1 days);
+        assertEq(tub.tab(cup), 110.25 ether);
+        tub.draw(cup, 100 ether);
+        assertEq(tub.tab(cup), 210.25 ether);
+    }
+    function testFeeTaxCalcFromRap() public {
+        var cup = feeSetup();
+
+        assertEq(tub.tab(cup), tub.rap(cup));
+        warp(1 days);
+        assertEq(tub.rap(cup), 105.00 ether);
+        assertEq(tub.tab(cup), 110.25 ether);
+    }
+    function testFeeTaxWipeAll() public {
+        var cup = feeSetup();
+        warp(1 days);
+
+        var wad = tub.tab(cup);
+        assertEq(wad, 110.25 ether);
+        var owe = sub(wad, rmul(wad, rdiv(tub.rap(cup), tub.tab(cup))));
+        assertEq(owe, 5.25 ether);
+
+        var ( , , art, irk) = tub.cups(cup);
+        assertEq(art, 100 ether);
+        assertEq(irk, 100 ether);
+        assertEq(rdiv(sub(wad, owe), tub.chi()), art);
+        assertEq(rdiv(wad, tub.rhi()), irk);
+
+        sai.mint(5 ether);  // need to magic up some extra sai to pay tax
+
+        assertEq(tub.tab(cup), 110.25 ether);
+        assertEq(gov.balanceOf(this), 100 ether);
+        tub.wipe(cup, 110.25 ether);
+        assertEq(tub.tab(cup), 0 ether);
+        assertEq(gov.balanceOf(this), 89.5 ether);
     }
 }

--- a/src/tub.sol
+++ b/src/tub.sol
@@ -23,8 +23,11 @@ contract SaiTub is DSThing, SaiTubEvents {
     DSToken  public  skr;  // Abstracted collateral
     ERC20    public  gem;  // Underlying collateral
 
+    DSToken  public  gov;  // Governance token
+
     SaiVox   public  vox;  // Target price feed
     DSValue  public  pip;  // Reference price feed
+    DSValue  public  pep;  // Governance price feed
 
     address  public  tap;  // Liquidator
 
@@ -32,6 +35,7 @@ contract SaiTub is DSThing, SaiTubEvents {
     uint256  public  hat;  // Debt ceiling
     uint256  public  mat;  // Liquidation ratio
     uint256  public  tax;  // Stability fee
+    uint256  public  fee;  // Governance fee
     uint256  public  gap;  // Join-Exit Spread
 
     bool     public  off;  // Cage flag
@@ -40,7 +44,8 @@ contract SaiTub is DSThing, SaiTubEvents {
     uint256  public  fit;  // REF per SKR (just before settlement)
 
     uint256  public  rho;  // Time of last drip
-    uint256          _chi;  // Price of internal debt unit
+    uint256         _chi;  // Accumulated Tax Rates
+    uint256         _rhi;  // Accumulated Tax + Fee Rates
 
     uint256                   public  cupi;
     mapping (bytes32 => Cup)  public  cups;
@@ -48,7 +53,8 @@ contract SaiTub is DSThing, SaiTubEvents {
     struct Cup {
         address  lad;      // CDP owner
         uint256  ink;      // Locked collateral (in SKR)
-        uint256  art;      // Outstanding debt (in internal debt units)
+        uint256  art;      // Outstanding normalised debt (tax only)
+        uint256  irk;      // Outstanding normalised debt
     }
 
     function lad(bytes32 cup) public view returns (address) {
@@ -58,6 +64,9 @@ contract SaiTub is DSThing, SaiTubEvents {
         return cups[cup].ink;
     }
     function tab(bytes32 cup) public returns (uint) {
+        return rmul(cups[cup].irk, rhi());
+    }
+    function rap(bytes32 cup) public returns (uint) {
         return rmul(cups[cup].art, chi());
     }
 
@@ -81,7 +90,9 @@ contract SaiTub is DSThing, SaiTubEvents {
         DSToken  sin_,
         DSToken  skr_,
         ERC20    gem_,
+        DSToken  gov_,
         DSValue  pip_,
+        DSValue  pep_,
         SaiVox   vox_,
         address  tap_
     ) public {
@@ -91,16 +102,21 @@ contract SaiTub is DSThing, SaiTubEvents {
         sai = sai_;
         sin = sin_;
 
+        gov = gov_;
+
         pip = pip_;
+        pep = pep_;
         vox = vox_;
         tap = tap_;
 
         axe = RAY;
         mat = RAY;
         tax = RAY;
+        fee = RAY;
         gap = WAD;
 
         _chi = RAY;
+        _rhi = RAY;
 
         rho = era();
     }
@@ -115,6 +131,7 @@ contract SaiTub is DSThing, SaiTubEvents {
         if      (param == 'hat') hat = val;
         else if (param == 'mat') mat = val;
         else if (param == 'tax') { drip(); tax = val; }
+        else if (param == 'fee') { drip(); fee = val; }
         else if (param == 'axe') axe = val;
         else if (param == 'gap') gap = val;
         else return;
@@ -147,10 +164,14 @@ contract SaiTub is DSThing, SaiTubEvents {
 
     //--Stability-fee-accumulation--------------------------------------
 
-    // Internal debt price (sai per debt unit)
+    // Accumulated Rates
     function chi() public returns (uint) {
         drip();
         return _chi;
+    }
+    function rhi() public returns (uint) {
+        drip();
+        return _rhi;
     }
     function drip() public note {
         if (off) return;
@@ -160,13 +181,26 @@ contract SaiTub is DSThing, SaiTubEvents {
         if (age == 0) return;    // optimised
         rho = rho_;
 
-        if (tax == RAY) return;  // optimised
-        var inc = rpow(tax, age);
+        var inct = RAY;
+        var incf = RAY;
 
-        if (inc == RAY) return;  // optimised
-        var dew = sub(rmul(ice(), inc), ice());
-        lend(tap, dew);
-        _chi = rmul(_chi, inc);
+        if (tax != RAY) {  // optimised
+            inct = rpow(tax, age);
+            var dew = sub(rmul(ice(), inct), ice());
+            lend(tap, dew);
+            _chi = rmul(_chi, inct);
+        }
+
+        if (fee != RAY) {  // optimised
+            incf = rpow(fee, age);
+            // hehe, cos ice is now ice.tax^age
+            var owe = sub(rmul(ice(), incf), ice());
+            sin.mint(owe);  // deferred gratitude
+        }
+
+        if (inct != RAY || incf != RAY) {  // optimised
+            _rhi = rmul(_rhi, rmul(inct, incf));
+        }
     }
 
     //--CDP-risk-indicator----------------------------------------------
@@ -188,10 +222,6 @@ contract SaiTub is DSThing, SaiTubEvents {
     function lend(address dst, uint wad) internal {
         sin.mint(wad);
         sai.mint(dst, wad);
-    }
-    function mend(address src, uint wad) internal {
-        sai.burn(src, wad);
-        sin.burn(wad);
     }
 
     //--CDP-operations--------------------------------------------------
@@ -226,6 +256,7 @@ contract SaiTub is DSThing, SaiTubEvents {
         require(msg.sender == cups[cup].lad);
 
         cups[cup].art = add(cups[cup].art, rdiv(wad, chi()));
+        cups[cup].irk = add(cups[cup].irk, rdiv(wad, rhi()));
         lend(cups[cup].lad, wad);
 
         require(safe(cup));
@@ -235,8 +266,14 @@ contract SaiTub is DSThing, SaiTubEvents {
         require(!off);
         require(msg.sender == cups[cup].lad);
 
-        cups[cup].art = sub(cups[cup].art, rdiv(wad, chi()));
-        mend(cups[cup].lad, wad);
+        var owe = sub(wad, rmul(wad, rdiv(rap(cup), tab(cup))));
+
+        cups[cup].art = sub(cups[cup].art, rdiv(sub(wad, owe), chi()));
+        cups[cup].irk = sub(cups[cup].irk, rdiv(wad, rhi()));
+
+        gov.burn(msg.sender, wdiv(owe, uint(pep.read())));
+        sai.burn(msg.sender, sub(wad, owe));
+        sin.burn(wad);
     }
 
     function shut(bytes32 cup) public note {
@@ -253,6 +290,7 @@ contract SaiTub is DSThing, SaiTubEvents {
         var rue = tab(cup);
         sin.push(tap, rue);
         cups[cup].art = 0;
+        cups[cup].irk = 0;
 
         // Amount owed in SKR, including liquidation penalty
         var owe = rdiv(rmul(rmul(rue, axe), vox.par()), tag());

--- a/src/tub.t.sol
+++ b/src/tub.t.sol
@@ -16,22 +16,26 @@ contract TubTest is DSTest, DSThing {
 	DSGuard dad;
 
 	DSValue pip;
+	DSValue pep;
 
 	DSToken sai;
 	DSToken sin;
 	DSToken skr;
 	DSToken gem;
+	DSToken gov;
 
 	function setUp() public {
 		sai = new DSToken("SAI");
 		sin = new DSToken("SIN");
 		skr = new DSToken("SKR");
 		gem = new DSToken("GEM");
+        gov = new DSToken("GOV");
 		pip = new DSValue();
+		pep = new DSValue();
 		dad = new DSGuard();
 		vox = new SaiVox();
 		tap = new SaiTap();
-		tub = new SaiTub(sai, sin, skr, gem, pip, vox, tap);
+		tub = new SaiTub(sai, sin, skr, gem, gov, pip, pep, vox, tap);
 
 		//Set whitelist authority 
 		skr.setAuthority(dad);


### PR DESCRIPTION
TODO: look for rounding errors, from extra complexity in `wipe`

Introduces a new risk parameter: the `fee`.

This is similar to the `tax`. Income from the `tax` is transferred to
SKR holders via `boom`, whereas the `fee` is paid in GOV, a governance
token, when debt is wiped from a CDP.

The ratio of GOV to SAI is provided by an external oracle `pep`.

Internally, we track a further rate accumulation, `rhi`, which is
calculated the same as `chi`, except including the `fee`. CDPs track the
`rap`, which is the debt normalised for `tax` and `fee` (`art` is
normalised only for `tax`).

This allows us to determine the fraction of the debt ascribing only to
`fee`, which is used in `drip` to calculate the additional sin to mint,
and in `wipe` to determine the fraction of the wiped amount to be paid
in GOV.