### PR TITLE
Add mock (opposite of cash)

### DIFF
--- a/src/tap.sol
+++ b/src/tap.sol
@@ -109,20 +109,23 @@ contract SaiTap is DSThing {
         off = true;
         fix = fix_;
     }
+
     function cash(uint wad) public note {
         require(off);
-        sai.pull(msg.sender, wad);
+        sai.pull(msg.sender, wad); // XXX: do sai.burn here instead
         require(tub.gem().transfer(msg.sender, rmul(wad, fix)));
     }
+
+    // XXX: add tests for mock
+    function mock(uint wad) public note {
+        require(off);
+        sai.mint(msg.sender, wad);
+        require(tub.gem().transferFrom(msg.sender, this, rmul(wad, fix)));
+    }
+
     function vent() public note {
         require(off);
-
-        // TODO: maybe this is vulnerable to rounding mismatch. Just
-        // accumulate the sai instead, or burn on cash.  Then all the
-        // sin from post-cage liquidation will just remain in the tap
-        // forever.
         heal();
-
         skr.burn(fog());
     }
 }


### PR DESCRIPTION
In case some dapps are still using (perhaps a hardcoded version of) a dai that has already been caged, there may be value in exchanging collateral for dai even after it has been caged.

We call this operation `mock`, since it basically creates "mock dai" (not the stablecoin dai). It was invented by @livnev and is basically the opposite of `cash`.

Note: need to add tests for this.

cc @rainbreak @nmushegian 